### PR TITLE
EmojiRegex::Text matches characters 0-9, #, and *

### DIFF
--- a/spec/emoji_regex/emoji_regex_spec.rb
+++ b/spec/emoji_regex/emoji_regex_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe EmojiRegex do
     end
 
     it "doesn't match non-emojis" do
-      expect("abc".scan(EmojiRegex::Regex)).to eql([])
+      expect("abc123#*".scan(EmojiRegex::Regex)).to eql([])
     end
   end
 
@@ -61,7 +61,7 @@ RSpec.describe EmojiRegex do
     end
 
     it "doesn't match non-emojis" do
-      expect("abc".scan(EmojiRegex::Text)).to eql([])
+      expect("abc123#*".scan(EmojiRegex::Text)).to eql([])
     end
   end
 end


### PR DESCRIPTION
I've added a failing test to show that the `EmojiRegex::Text` regexp (but not `EmojiRegex::Regex`) is incorrectly matching characters `0-9`, `#`, and `*`. There are a couple of occurrences of `#\*0-9` in both of the regexps and when they're removed the test passes (though strangely of course `EmojiRegex::Regex` doesn't fail in the first place).

Adding the following test to [github.com/mathiasbynens/emoji-regex](https://github.com/mathiasbynens/emoji-regex) passes which suggests to me that the problem lies in this repo's regenerate script:

```js
it('does not match non-emoji characters', function() {
  assert(!emojiRegex().test('abc123#*'));
});
```

I've come to the end of my immediate knowledge and wonder if an obvious fix springs into your mind? Otherwise I will continue to investigate.
